### PR TITLE
🐛 Fix: 修正bigfoot内容框被图片覆盖问题

### DIFF
--- a/assets/bigfoot/bigfoot.css
+++ b/assets/bigfoot/bigfoot.css
@@ -74,7 +74,7 @@
   }
   .bigfoot-footnote {
     position: absolute;
-    z-index: 10;
+    z-index: 991;
     top: 0;
     left: 0;
     display: inline-block;


### PR DESCRIPTION
问题示意：

![](https://raw.githubusercontent.com/Sevichecc/obsidian-image/main/img202301272209214.png)