### PR TITLE
🐛 Fix: 修复单词被截断，不自动换行问题

### DIFF
--- a/assets/matcha/matcha.post.css
+++ b/assets/matcha/matcha.post.css
@@ -33,7 +33,6 @@
 .post-title-atpage {
 	font-size: 1.7em;
 	margin-top: .9em;
-	font-weight: 400;
 	position: relative;
     font-weight: 700
 }
@@ -112,6 +111,7 @@
 .post-content,.comment-content {
 	line-height: 1.5;
 	word-wrap: break-word;
+	word-break: break-word;
 }
 
 .post-content h2,


### PR DESCRIPTION
## 现有问题

https://blog.guhub.cn/

当 apply 单词位于行末时，y 被截断为新的一行

![image](https://user-images.githubusercontent.com/27202776/222161231-1c6f5e48-96b5-40d8-beed-b7d209e1bcbf.png)

## 修改之后

![image](https://user-images.githubusercontent.com/27202776/222161452-a53ed929-946f-49e5-b239-a405b6959785.png)

## 其他

* 顺便去除了一个冗余样式

