### PR TITLE
:bug: Fix: 评论模块「退出」按钮失效

### DIFF
--- a/includes/comments.php
+++ b/includes/comments.php
@@ -75,7 +75,7 @@ Comments::replyScript($this); ?>
                   <?php $this->author->gravatar(32); ?>
                   <div class="comments-profile-author">
                     <a class="comments-profile-name" href="<?php $this->options->profileUrl(); ?>"><?php $this->user->screenName(); ?></a><br>
-                    <a class="comments-logout" href="<?php $this->options->logoutUrl(); ?>" title="Logout"><?php _e('退出'); ?></a>
+                    <a class="comments-logout" href="<?php $this->options->logoutUrl(); ?>" title="Logout" no-pjax><?php _e('退出'); ?></a>
                   </div>
                 </div>
                 <script>login=true;</script>


### PR DESCRIPTION
修复 #15 中提到的退出功能无法正常工作，这可能是受到了 pjax 的影响。

经测试，不使用 pjax 可以规避此问题。

------

此外，用户还应注意的是，内容加速网络（CDN）服务所提供的缓存选项中不应选择忽略 GET 请求参数，这也会导致动态网站出现问题。